### PR TITLE
Do not duplicate call to loader on loader error

### DIFF
--- a/src/errorResilient.ts
+++ b/src/errorResilient.ts
@@ -76,7 +76,7 @@ export class ErrorResilientCache<K, V> implements CacheProvider<K, V> {
     private logLoaderError(error: unknown): void {
         this.logger.log({
             level: LogLevel.ERROR,
-            message: 'Error detected on cache loader error.',
+            message: 'Error detected on cache loader.',
             details: {
                 errorMessage: extractErrorMessage(error),
                 errorStack: error instanceof Error ? error.stack : undefined,

--- a/test/errorResilient.test.ts
+++ b/test/errorResilient.test.ts
@@ -74,7 +74,7 @@ describe('An error-resilient cache wrapper', () => {
         expect(logger.getLogs()).toStrictEqual<Log[]>([
             {
                 level: LogLevel.ERROR,
-                message: 'Error detected on cache loader error.',
+                message: 'Error detected on cache loader.',
                 details: {
                     errorMessage: loaderError.message,
                     errorStack: loaderError.stack,


### PR DESCRIPTION
## Summary

Fix loader being called twice when it fails, possibly worsening the underlying problem due to the doubling of the request rate.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings