### PR TITLE
Set this library as side effect free

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "types": "index.d.ts",
   "main": "index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/croct-tech/cache-js.git"


### PR DESCRIPTION
## Summary

Add a flag to the `package.json` file indicating to bundlers that the modules in this library do not have side effects. This allows better optimizations and code pruning from the any bundle using this library.

Webpack has a [nice example][1] file on how this property affects bundling and code pruning

[1]: https://github.com/webpack/webpack/blob/1e18b1d1c74e26a84e9adee519c045e2d8ed40a4/examples/side-effects/README.md

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings