### PR TITLE
Improve error handling

### DIFF
--- a/src/defaultWhileMiss.ts
+++ b/src/defaultWhileMiss.ts
@@ -6,7 +6,7 @@ export type Configuration<K, V> = {
     /**
      * Handler for background revalidation errors
      */
-    errorHandler?: (error: Error) => void,
+    errorHandler?: (key: K, error: Error) => void,
 };
 
 export class DefaultWhileMissCache<K, V> implements CacheProvider<K, V> {
@@ -14,7 +14,7 @@ export class DefaultWhileMissCache<K, V> implements CacheProvider<K, V> {
 
     private readonly defaultValue: V;
 
-    private readonly errorHandler: (error: Error) => void;
+    private readonly errorHandler: (key: K, error: Error) => void;
 
     public constructor(config: Configuration<K, V>) {
         this.provider = config.provider;
@@ -24,7 +24,7 @@ export class DefaultWhileMissCache<K, V> implements CacheProvider<K, V> {
 
     public get(key: K, loader: CacheLoader<K, V>): Promise<V> {
         return this.provider.get(key, innerKey => {
-            loader(innerKey).catch(this.errorHandler);
+            loader(innerKey).catch(error => this.errorHandler(key, error));
 
             return Promise.resolve(this.defaultValue);
         });

--- a/test/defaultWhileMiss.test.ts
+++ b/test/defaultWhileMiss.test.ts
@@ -44,7 +44,7 @@ describe('A cache provider that returns a default value while loading in the bac
         expect(loader).toHaveBeenCalledWith('key');
 
         expect(errorHandler).toHaveBeenCalledTimes(1);
-        expect(errorHandler).toHaveBeenCalledWith(error);
+        expect(errorHandler).toHaveBeenCalledWith('key', error);
     });
 
     it('should delegate setting a value to the underlying provider', async () => {


### PR DESCRIPTION
## Summary
This PR improves the following implementations:
- Stale while revalidate
    - Pass the `key` to the error callback, so that the caller is able to update or delete the key of a failed operation
    - Receives either a number or a function returning a number for the fresh period, so the caller is able to provide a custom logic based on the operation `key` and `value`;
- Hold while revalidate
    - Receives either a number or a function returning a number for the fresh period, so the caller is able to provide a custom logic based on the operation `key` and `value`;
-  Default while miss
    - Pass the `key` to the error callback, so that the caller is able to update or delete the key of a failed operation;

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings