### PR TITLE
Defer default while miss cache loader

### DIFF
--- a/src/defaultWhileMiss.ts
+++ b/src/defaultWhileMiss.ts
@@ -24,7 +24,9 @@ export class DefaultWhileMissCache<K, V> implements CacheProvider<K, V> {
 
     public get(key: K, loader: CacheLoader<K, V>): Promise<V> {
         return this.provider.get(key, innerKey => {
-            loader(innerKey).catch(error => this.errorHandler(key, error));
+            // Schedule loading in the next tick avoiding resolving
+            // before the surrounding cache retrieval resolves
+            setImmediate(() => loader(innerKey).catch(error => this.errorHandler(key, error)));
 
             return Promise.resolve(this.defaultValue);
         });

--- a/test/defaultWhileMiss.test.ts
+++ b/test/defaultWhileMiss.test.ts
@@ -1,3 +1,4 @@
+import * as timers from 'node:timers/promises';
 import {DefaultWhileMissCache, NoopCache} from '../src';
 
 describe('A cache provider that returns a default value while loading in the background', () => {
@@ -16,6 +17,8 @@ describe('A cache provider that returns a default value while loading in the bac
         await expect(cache.get('key', loader)).resolves.toBe('defaultValue');
 
         expect(provider.get).toHaveBeenCalledWith('key', expect.any(Function));
+
+        await timers.setImmediate();
 
         expect(loader).toHaveBeenCalledWith('key');
     });
@@ -40,6 +43,8 @@ describe('A cache provider that returns a default value while loading in the bac
         await expect(cache.get('key', loader)).resolves.toBe('defaultValue');
 
         expect(provider.get).toHaveBeenCalledWith('key', expect.any(Function));
+
+        await timers.setImmediate();
 
         expect(loader).toHaveBeenCalledWith('key');
 


### PR DESCRIPTION
## Summary
This PR defers the `Default while miss cache` loader execution to ensure the default value is returned before the surrounding cache executes, avoiding a potential race condition.

Related to:
- Closes #120 

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings